### PR TITLE
Support for Android hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ I did some improvments for my needs. Current devel branch version seems to be ve
 There are several changes, main differences:
 
 *   Windows 10 Support
+*   Support for Android hosts (tested with CyanogenMod 11 [Android 4.4], requires busybox to be installed)
 *   current Renci SSH (2014.4.6beta)
 *   solved few bugs like payload, 2 hosts and others
 *   Puttyant (Pageant) support


### PR DESCRIPTION
Fixes #31.

Android doesn't have POSIX `id` or `df`, have to use their busybox equivalents instead.
Renci.Ssh also throws `SshException` while trying to request the drive size from an Android host, which needs to be handled, otherwise there won't be any drive size information.
Without drive size information copy-paste and drag-and-drop operations fail in Explorer.
