### PR TITLE
dh key exchange: change group size to 2048

### DIFF
--- a/Renci.SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha1.cs
+++ b/Renci.SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha1.cs
@@ -34,8 +34,8 @@ namespace Renci.SshNet.Security
                 ServerPayload = this._serverPayload,
                 HostKey = this._hostKey,
                 MinimumGroupSize = 1024,
-                PreferredGroupSize = 1024,
-                MaximumGroupSize = 1024,
+                PreferredGroupSize = 2048,
+                MaximumGroupSize = 2048,
                 Prime = this._prime,
                 SubGroup = this._group,
                 ClientExchangeValue = this._clientExchangeValue,
@@ -61,7 +61,7 @@ namespace Renci.SshNet.Security
             this.Session.MessageReceived += Session_MessageReceived;
 
             //  1. send SSH_MSG_KEY_DH_GEX_REQUEST
-            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024, 1024, 1024));
+            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024, 2048, 2048));
         }
 
         /// <summary>

--- a/Renci.SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
+++ b/Renci.SshNet/Security/KeyExchangeDiffieHellmanGroupExchangeSha256.cs
@@ -34,7 +34,7 @@ namespace Renci.SshNet.Security
             this.Session.MessageReceived += Session_MessageReceived;
 
             //  1. send SSH_MSG_KEY_DH_GEX_REQUEST
-            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024,1024,1024));
+            this.SendMessage(new KeyExchangeDhGroupExchangeRequest(1024,2048,2048));
             
         }
 
@@ -64,8 +64,8 @@ namespace Renci.SshNet.Security
                 ServerPayload = this._serverPayload,
                 HostKey = this._hostKey,
                 MinimumGroupSize = 1024,
-                PreferredGroupSize = 1024,
-                MaximumGroupSize = 1024,
+                PreferredGroupSize = 2048,
+                MaximumGroupSize = 2048,
                 Prime = this._prime,
                 SubGroup = this._group,
                 ClientExchangeValue = this._clientExchangeValue,


### PR DESCRIPTION
Fixes #81. The change was inspired by discussion [here](https://sourceforge.net/p/jsch/mailman/message/33597066/).
